### PR TITLE
Группировка комментариев

### DIFF
--- a/app/Builders/NoteBuilder.php
+++ b/app/Builders/NoteBuilder.php
@@ -14,11 +14,18 @@ class NoteBuilder extends TriggerBuilder
         $userLink = $this->getTrigger()->getUserProfileLink();
         $objectUrl = $this->getTrigger()->getObjectUrl();
         $noteableType = $this->getRequest()->objectAttributes->noteable_type;
-        $iid = match ($noteableType) {
-            'MergeRequest' => $this->getRequest()->mergeRequest->iid,
-            'Issue' => $this->getRequest()->issue->iid,
-        };
-
+        $iid = $this->getRequest()->iid;
         $this->addLine("Пользователь [$userName]($userLink) оставил [комментарий]($objectUrl) к $noteableType №$iid");
+    }
+
+    public function addUserActionTextMultipleMessages(int $count): void
+    {
+        $userName = $this->getTrigger()->getUserName();
+        $userLink = $this->getTrigger()->getUserProfileLink();
+        $noteableType = $this->getRequest()->objectAttributes->noteable_type;
+        $objectUrl = $this->getTrigger()->getObjectUrl();
+        $iid = $this->getRequest()->iid;
+        $text = declOfNum($count, ['%d комментарий', '%d комментария', '%d комментариев']);
+        $this->addLine("Пользователь [$userName]($userLink) оставил [$text]($objectUrl) к $noteableType №$iid");
     }
 }

--- a/app/Helpers/helpers.php
+++ b/app/Helpers/helpers.php
@@ -15,6 +15,7 @@ if (!function_exists('get_sqlite_db_path')) {
 if (!function_exists('declOfNum')) {
     /**
      * Функция склонения числительных в русском языке
+     *
      * @param int $number Число которое нужно просклонять
      * @param array $titles Массив слов для склонения ['%d комментарий', '%d комментария', '%d комментариев']
      * @return string
@@ -23,6 +24,7 @@ if (!function_exists('declOfNum')) {
     {
         $cases = [2, 0, 1, 1, 1, 2];
         $format = $titles[($number % 100 > 4 && $number % 100 < 20) ? 2 : $cases[min($number % 10, 5)]];
+
         return sprintf($format, $number);
     }
 }

--- a/app/Helpers/helpers.php
+++ b/app/Helpers/helpers.php
@@ -11,3 +11,18 @@ if (!function_exists('get_sqlite_db_path')) {
         return $path;
     }
 }
+
+if (!function_exists('declOfNum')) {
+    /**
+     * Функция склонения числительных в русском языке
+     * @param int $number Число которое нужно просклонять
+     * @param array $titles Массив слов для склонения ['%d комментарий', '%d комментария', '%d комментариев']
+     * @return string
+     */
+    function declOfNum(int $number, array $titles): string
+    {
+        $cases = [2, 0, 1, 1, 1, 2];
+        $format = $titles[($number % 100 > 4 && $number % 100 < 20) ? 2 : $cases[min($number % 10, 5)]];
+        return sprintf($format, $number);
+    }
+}

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Comment extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'reference',
+        'object_id',
+        'chat_id',
+        'author_id',
+        'message_id'
+    ];
+}

--- a/app/Models/Core/Telegram.php
+++ b/app/Models/Core/Telegram.php
@@ -26,4 +26,11 @@ class Telegram
 
         return Request::sendMessage($data);
     }
+
+    public static function editMessage($data): ServerResponse
+    {
+        Request::initialize(Telegram::getInstance());
+
+        return Request::editMessageText($data);
+    }
 }

--- a/app/Models/Gitlab/Request.php
+++ b/app/Models/Gitlab/Request.php
@@ -6,14 +6,15 @@ use App\Models\Core\Json;
 
 class Request
 {
-    public null|string $type;
+    public ?string $type;
     public User $user;
     public Project $project;
     public ObjectAttributes $objectAttributes;
     public MergeRequest $mergeRequest;
     public Issue $issue;
     public Commit $commit;
-    public null|string $host;
+    public ?string $host;
+    public ?int $iid;
 
     public function __construct(Json $data, $host = null)
     {
@@ -24,7 +25,10 @@ class Request
         $this->mergeRequest = new MergeRequest(new Json($data->get('merge_request')));
         $this->issue = new Issue(new Json($data->get('issue')));
         $this->commit = new Commit(new Json($data->get('commit')));
-
+        $this->iid = match ($this->objectAttributes->noteable_type) {
+            'MergeRequest' => $this->mergeRequest->iid,
+            'Issue' => $this->issue->iid,
+        };
         $this->host = $host;
     }
 }

--- a/database/migrations/2023_06_01_082703_create_comments_table.php
+++ b/database/migrations/2023_06_01_082703_create_comments_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('comments', function (Blueprint $table) {
+            $table->id();
+            $table->integer('reference')->nullable();
+            $table->bigInteger('object_id')->nullable(false);
+            $table->bigInteger('author_id')->nullable(false);
+            $table->bigInteger('chat_id')->nullable(false);
+            $table->bigInteger('message_id')->nullable(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('comments');
+    }
+};


### PR DESCRIPTION
Теперь, при массовой отправки комментариев (или при окончании ревью или просто при быстрой отправке нескольких комментариев) они группируются, что позволяет избежать спама однотипными сообщениями. Логика такова, что система группирует комментарии по объекту комментирования и пользователю, а так же по времени (сообщения группируются в течении одной минуты)